### PR TITLE
Enable status icon changes to persist across reboots

### DIFF
--- a/custom_components/view_assist/helpers.py
+++ b/custom_components/view_assist/helpers.py
@@ -5,7 +5,6 @@ import json
 import logging
 from pathlib import Path
 from typing import Any, List, Optional, Union
-import json
 
 import requests
 

--- a/custom_components/view_assist/manifest.json
+++ b/custom_components/view_assist/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/dinki/view_assist_integration/issues",
   "requirements": ["wordtodigits==1.0.2"],
-  "version": "2025.4.0"
+  "version": "2025.4.1"
 }


### PR DESCRIPTION
Add persistence to status icons and menu items added through service calls by saving changes to config entry options. Previously, these changes were only stored in memory and entity attributes, causing them to be lost after a Home Assistant restart. This change ensures user customizations survive system reboots.