### PR TITLE
Replace Boolean Menu Options with Single Dropdown Configuration

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -59,6 +59,7 @@ from .typed import (
     VABackgroundMode,
     VAConfigEntry,
     VAEvent,
+    VAMenuConfig,
     VAScreenMode,
     VATimeFormat,
     VAType,

--- a/custom_components/view_assist/config_flow.py
+++ b/custom_components/view_assist/config_flow.py
@@ -37,13 +37,12 @@ from .const import (
     CONF_DISPLAY_DEVICE,
     CONF_DISPLAY_SETTINGS,
     CONF_DO_NOT_DISTURB,
-    CONF_ENABLE_MENU,
-    CONF_ENABLE_MENU_TIMEOUT,
     CONF_FONT_STYLE,
     CONF_HOME,
     CONF_INTENT,
     CONF_INTENT_DEVICE,
     CONF_MEDIAPLAYER_DEVICE,
+    CONF_MENU_CONFIG,
     CONF_MENU_ITEMS,
     CONF_MENU_TIMEOUT,
     CONF_MIC_DEVICE,
@@ -54,7 +53,6 @@ from .const import (
     CONF_ROTATE_BACKGROUND_LINKED_ENTITY,
     CONF_ROTATE_BACKGROUND_PATH,
     CONF_SCREEN_MODE,
-    CONF_SHOW_MENU_BUTTON,
     CONF_STATUS_ICON_SIZE,
     CONF_STATUS_ICONS,
     CONF_TIME_FORMAT,
@@ -70,7 +68,14 @@ from .const import (
     VAIconSizes,
 )
 from .helpers import get_devices_for_domain, get_master_config_entry
-from .typed import VABackgroundMode, VAConfigEntry, VAScreenMode, VATimeFormat, VAType
+from .typed import (
+    VABackgroundMode,
+    VAConfigEntry,
+    VAMenuConfig,
+    VAScreenMode,
+    VATimeFormat,
+    VAType,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -219,7 +224,13 @@ def get_dashboard_options_schema(config_entry: VAConfigEntry | None) -> vol.Sche
                 custom_value=True,
             )
         ),
-        vol.Optional(CONF_ENABLE_MENU): bool,
+        vol.Optional(CONF_MENU_CONFIG): SelectSelector(
+            SelectSelectorConfig(
+                translation_key="menu_config_selector",
+                options=[e.value for e in VAMenuConfig],
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
         vol.Optional(CONF_MENU_ITEMS): SelectSelector(
             SelectSelectorConfig(
                 translation_key="menu_icons_selector",
@@ -229,8 +240,6 @@ def get_dashboard_options_schema(config_entry: VAConfigEntry | None) -> vol.Sche
                 custom_value=True,
             )
         ),
-        vol.Optional(CONF_SHOW_MENU_BUTTON): bool,
-        vol.Optional(CONF_ENABLE_MENU_TIMEOUT): bool,
         vol.Optional(CONF_MENU_TIMEOUT): int,
         vol.Optional(CONF_TIME_FORMAT): SelectSelector(
             SelectSelectorConfig(

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -8,6 +8,7 @@ from .typed import (
     VAAssistPrompt,
     VABackgroundMode,
     VAIconSizes,
+    VAMenuConfig,
     VAScreenMode,
     VATimeFormat,
 )
@@ -102,10 +103,8 @@ CONF_ASSIST_PROMPT = "assist_prompt"
 CONF_STATUS_ICON_SIZE = "status_icons_size"
 CONF_FONT_STYLE = "font_style"
 CONF_STATUS_ICONS = "status_icons"
-CONF_ENABLE_MENU = "enable_menu"
+CONF_MENU_CONFIG = "menu_config"
 CONF_MENU_ITEMS = "menu_items"
-CONF_SHOW_MENU_BUTTON = "show_menu_button"
-CONF_ENABLE_MENU_TIMEOUT = "enable_menu_timeout"
 CONF_MENU_TIMEOUT = "menu_timeout"
 CONF_TIME_FORMAT = "time_format"
 CONF_SCREEN_MODE = "screen_mode"
@@ -149,10 +148,8 @@ DEFAULT_VALUES = {
         CONF_STATUS_ICON_SIZE: VAIconSizes.LARGE,
         CONF_FONT_STYLE: "Roboto",
         CONF_STATUS_ICONS: [],
-        CONF_ENABLE_MENU: False,
+        CONF_MENU_CONFIG: VAMenuConfig.DISABLED,
         CONF_MENU_ITEMS: ["home", "weather"],
-        CONF_SHOW_MENU_BUTTON: False,
-        CONF_ENABLE_MENU_TIMEOUT: False,
         CONF_MENU_TIMEOUT: 10,
         CONF_TIME_FORMAT: VATimeFormat.HOUR_12,
         CONF_SCREEN_MODE: VAScreenMode.HIDE_HEADER_SIDEBAR,

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -107,9 +107,8 @@ class ViewAssistSensor(SensorEntity):
             # Dashboard settings
             "status_icons": r.dashboard.display_settings.status_icons,
             "status_icons_size": r.dashboard.display_settings.status_icons_size,
-            "enable_menu": r.dashboard.display_settings.enable_menu,
+            "menu_config": r.dashboard.display_settings.menu_config,
             "menu_items": r.dashboard.display_settings.menu_items,
-            "show_menu_button": r.dashboard.display_settings.show_menu_button,
             "menu_active": self._get_menu_active_state(),
             "assist_prompt": self.get_option_key_migration_value(
                 r.dashboard.display_settings.assist_prompt

--- a/custom_components/view_assist/translations/en.json
+++ b/custom_components/view_assist/translations/en.json
@@ -114,10 +114,8 @@
               "status_icons_size": "Status icon size",
               "font_style": "Font style",
               "status_icons": "Launch icons",
-              "enable_menu": "Enable menu",
+              "menu_config": "Menu configuration",
               "menu_items": "Menu items",
-              "show_menu_button": "Show menu button",
-              "enable_menu_timeout": "Enable menu timeout",
               "menu_timeout": "Menu timeout",
               "time_format": "Time format",
               "screen_mode": "Show/hide header and sidebar"
@@ -127,11 +125,9 @@
               "status_icons_size": "Size of the icons in the status icon display",
               "font_style": "The default font to use for this satellite device. Font name must match perfectly and be available",
               "status_icons": "Advanced option! List of custom launch icons to set on start up. Do not change this if you do not know what you are doing",
-              "enable_menu": "Enable or disable the menu feature for this device",
+              "menu_config": "Configure the menu behavior",
               "menu_items": "List of items to show in the menu when activated",
-              "show_menu_button": "Always show the menu toggle button in the status bar",
-              "enable_menu_timeout": "Automatically close the menu after timeout period",
-              "menu_timeout": "Time in seconds before menu automatically closes",
+              "menu_timeout": "Time in seconds before menu automatically closes (0 to disable timeout)",
               "time_format": "Sets clock display time format",
               "screen_mode": "Show or hide the header and sidebar"
             }
@@ -189,6 +185,13 @@
         "6vw": "Small",
         "7vw": "Medium",
         "8vw": "Large"
+      }
+    },
+    "menu_config_selector": {
+      "options": {
+        "menu_disabled": "Menu disabled",
+        "menu_enabled_button_visible": "Menu enabled, button visible",
+        "menu_enabled_button_hidden": "Menu enabled, button hidden"
       }
     },
     "mic_type_selector": {

--- a/custom_components/view_assist/typed.py
+++ b/custom_components/view_assist/typed.py
@@ -66,6 +66,12 @@ class VABackgroundMode(StrEnum):
     DOWNLOAD_RANDOM = "download"
     LINKED = "link_to_entity"
 
+class VAMenuConfig(StrEnum):
+    """Menu configuration options enum."""
+    DISABLED = "menu_disabled"
+    ENABLED_VISIBLE = "menu_enabled_button_visible" 
+    ENABLED_HIDDEN = "menu_enabled_button_hidden"
+
 
 @dataclass
 class DeviceCoreConfig:
@@ -100,13 +106,11 @@ class DisplayConfig:
     status_icons_size: VAIconSizes | None = None
     font_style: str | None = None
     status_icons: list[str] = field(default_factory=list)
+    menu_config: VAMenuConfig = VAMenuConfig.DISABLED
+    menu_items: list[str] = field(default_factory=list)
+    menu_timeout: int = 10
     time_format: VATimeFormat | None = None
     screen_mode: VAScreenMode | None = None
-    enable_menu: bool = False
-    menu_items: list[str] = field(default_factory=list)
-    show_menu_button: bool = False
-    enable_menu_timeout: bool = False
-    menu_timeout: int = 10
 
 
 @dataclass


### PR DESCRIPTION
This PR refactors the menu configuration system to improve usability and fix edge cases. Instead of three separate boolean toggles (enable_menu, show_menu_button, enable_menu_timeout), it implements:

1. A single dropdown selector with options for "disabled", "enabled with visible button", and "enabled with hidden button"
2. Uses the menu_timeout value to determine if timeout is enabled (0 = no timeout, >0 = timeout enabled)

This fixes an important edge case where menu settings from the master config couldn't be overridden in individual device configs. The approach matches the pattern used elsewhere (ex. header/sidebar configuration).