### PR TITLE
Reverse menu item ordering for improved UI consistency

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -335,6 +335,8 @@ def set_runtime_data_for_config(  # noqa: C901
                             if sub_value := get_config_value(
                                 f"{attr}.{sub_attr}", is_master=True
                             ):
+                                if sub_attr == "menu_items":
+                                    sub_value = list(reversed(ensure_list(sub_value)))
                                 values[sub_attr] = sub_value
                         value = type(getattr(r.dashboard, attr))(**values)
                     setattr(r.dashboard, attr, value)
@@ -371,6 +373,8 @@ def set_runtime_data_for_config(  # noqa: C901
                         values = {}
                         for sub_attr in getattr(r.dashboard, attr).__dict__:
                             if sub_value := get_config_value(f"{attr}.{sub_attr}"):
+                                if sub_attr == "menu_items":
+                                    sub_value = list(reversed(ensure_list(sub_value)))
                                 values[sub_attr] = sub_value
                         value = type(getattr(r.dashboard, attr))(**values)
                     setattr(r.dashboard, attr, value)

--- a/custom_components/view_assist/menu_manager.py
+++ b/custom_components/view_assist/menu_manager.py
@@ -286,7 +286,7 @@ class MenuManager:
 
             for item in items:
                 if item not in updated_items:
-                    updated_items.append(item)
+                    updated_items.insert(0, item)
                     changed = True
 
             if changed:
@@ -394,12 +394,15 @@ class MenuManager:
         """Save options to config entry for persistence."""
         config_entry = get_config_entry_by_entity_id(self.hass, entity_id)
         if not config_entry:
-            _LOGGER.warning(
-                "Cannot save %s - config entry not found", option_key)
+            _LOGGER.warning("Cannot save %s - config entry not found", option_key)
             return
 
         try:
             new_options = dict(config_entry.options)
+            
+            if option_key == CONF_MENU_ITEMS:
+                value = list(reversed(value))
+                
             new_options[option_key] = value
             self.hass.config_entries.async_update_entry(
                 config_entry, options=new_options)


### PR DESCRIPTION
Updates the menu system to display items in right-to-left order, with the first configured item appearing rightmost (adjacent to system icons) and dynamically added items appearing on the left. This creates a more intuitive interface where newer items appear on the left and older items on the right while maintaining the proper separation between menu items, system icons, and the menu toggle button.